### PR TITLE
Handle IE 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject malcontent "0.1.0-SNAPSHOT"
+(defproject tech.droit/malcontent "0.1.0-SNAPSHOT"
   :description "Ring middleware for HTTP Content Security Policy"
-  :url "http://github.com/ecmendenhall/malcontent"
+  :url "http://github.com/droitfintech/malcontent"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]

--- a/src/malcontent/browser.clj
+++ b/src/malcontent/browser.clj
@@ -37,7 +37,8 @@
     (or (and (= "FIREFOX" browser-family)
              (<= browser-version 23))
         (and (= "IE" browser-family)
-             (<= browser-version 10)))))
+             (<= browser-version 10))
+        (= "MOZILLA" browser-family)))) ; IE 11 spoofs Mozilla!
 
 (defn webkit-header? [browser]
   (let [browser-family  (browser :family)

--- a/src/malcontent/middleware.clj
+++ b/src/malcontent/middleware.clj
@@ -14,5 +14,3 @@
                  (make-policy (if config-path
                                 (load-policy config-path)
                                 (load-policy)))))))))
-                              
-


### PR DESCRIPTION
Currently consuming an IE 11 user agent string:

    user=> (def agent "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")
    user=> (b/parse-user-agent-string agent)
    {:family "MOZILLA", :name "Mozilla", :version [0 0 0]}

Since I guess those were the years Microsoft starting giving up and tried
to trick clients into thinking they were Mozilla instead.

Unfortunately, the current implementation sends the `Content-Security-Header`
in that scenario, rather than the needed `X-Content-Security-Header` field that IE 11
expects.

Thus we try to catch user-agents of this form and produce the needed header name.

Also (finishing the fork):
 * Rewrite group ID
 * Update URL